### PR TITLE
[Fix] Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
+      
+      - name: Setup PNPM
+        run: |
+          npm install -g pnpm
 
       - name: Install Dependencies
         run: pnpm


### PR DESCRIPTION
The `Release` Changesets action did not setup PNPM https://github.com/powersync-ja/powersync-web-sdk/actions/runs/6850448538.

This installs PNPM for the action to function.