### PR TITLE
chore: update wa-sqlite

### DIFF
--- a/packages/powersync-sdk-web/package.json
+++ b/packages/powersync-sdk-web/package.json
@@ -35,10 +35,10 @@
     "@types/lodash": "^4.14.200",
     "@types/uuid": "^9.0.6",
     "typescript": "^5.2.2",
-    "@journeyapps/wa-sqlite": "0.0.1"
+    "@journeyapps/wa-sqlite": "0.0.2"
   },
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "0.0.1"
+    "@journeyapps/wa-sqlite": "0.0.2"
   },
   "dependencies": {
     "@journeyapps/powersync-sdk-common": "0.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         version: 9.0.1
     devDependencies:
       '@journeyapps/wa-sqlite':
-        specifier: 0.0.1
-        version: 0.0.1
+        specifier: 0.0.2
+        version: 0.0.2
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -573,6 +573,11 @@ packages:
 
   /@journeyapps/wa-sqlite@0.0.1:
     resolution: {integrity: sha512-lsaPhjCZbHhAZ5JpftJTWL0JkVipja/PrF6Xno/lzFOWledfszvnMtvCZfGNxCaiGljk3ds3Hg5erPzGD+z1uw==}
+    dev: false
+
+  /@journeyapps/wa-sqlite@0.0.2:
+    resolution: {integrity: sha512-qSuSQyzopPiwQd/ChAWe3Po/OzeVrcpWc8KVFzHfhnqR2O3L2bHjsLRsQrnx9hZAF71WNhxfhxF5gGqcbfXmZw==}
+    dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}


### PR DESCRIPTION
## Description
Update wa-sqlite version as it creates an error when installing a newer version of the sdk
```
npm ERR! Found: @journeyapps/wa-sqlite@0.0.2
npm ERR! node_modules/@journeyapps/wa-sqlite
npm ERR!   @journeyapps/wa-sqlite@"^0.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @journeyapps/wa-sqlite@"0.0.1" from @journeyapps/powersync-sdk-web@0.0.2
```
## Work Done
Updated the `@journeyapps/wa-sqlite` peer dependency version.