### PR TITLE
[Update] Throttled updates

### DIFF
--- a/.changeset/famous-frogs-eat.md
+++ b/.changeset/famous-frogs-eat.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Fix bug where opening multiple WA-SQLite instances would erase DB table change watches.

--- a/.changeset/lucky-gorillas-hunt.md
+++ b/.changeset/lucky-gorillas-hunt.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Update common SDK dependency to v1.0.1: Improved connector CRUD uploads to be triggered whenever an internal CRUD operation change is triggered. Improved CRUD upload debouncing to rather use a throttled approach - executing multiple continuous write/CRUD operations will now trigger a connector upload at most (every) 1 second (by default).

--- a/.changeset/twelve-geckos-shop.md
+++ b/.changeset/twelve-geckos-shop.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-nextjs-demo': patch
+---
+
+Autofocus inputs in creation dialogs for a better UX.

--- a/demos/powersync-nextjs-demo/package.json
+++ b/demos/powersync-nextjs-demo/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
-    "@journeyapps/powersync-react": "1.0.0",
+    "@journeyapps/powersync-react": "0.0.0-dev-20240115090623",
     "@journeyapps/powersync-sdk-web": "workspace:*",
     "@journeyapps/wa-sqlite": "~0.1.0",
     "@mui/icons-material": "^5.14.16",

--- a/demos/powersync-nextjs-demo/package.json
+++ b/demos/powersync-nextjs-demo/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
-    "@journeyapps/powersync-react": "0.0.0-dev-20240115090623",
+    "@journeyapps/powersync-react": "1.0.1",
     "@journeyapps/powersync-sdk-web": "workspace:*",
     "@journeyapps/wa-sqlite": "~0.1.0",
     "@mui/icons-material": "^5.14.16",

--- a/demos/powersync-nextjs-demo/src/app/views/todo-lists/edit/page.tsx
+++ b/demos/powersync-nextjs-demo/src/app/views/todo-lists/edit/page.tsx
@@ -126,7 +126,7 @@ const TodoEditSection = () => {
           <DialogTitle id="alert-dialog-title">{'Create Todo Item'}</DialogTitle>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">Enter a description for a new todo item</DialogContentText>
-            <TextField sx={{ marginTop: '10px' }} fullWidth inputRef={nameInputRef} label="Name" />
+            <TextField sx={{ marginTop: '10px' }} fullWidth inputRef={nameInputRef} autoFocus label="Name" />
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setShowPrompt(false)}>Cancel</Button>

--- a/demos/powersync-nextjs-demo/src/app/views/todo-lists/page.tsx
+++ b/demos/powersync-nextjs-demo/src/app/views/todo-lists/page.tsx
@@ -103,7 +103,7 @@ export default function TodoListsPage() {
           <DialogTitle id="alert-dialog-title">{'Create Todo List'}</DialogTitle>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">Enter a name for a new todo list</DialogContentText>
-            <TextField sx={{ marginTop: '10px' }} fullWidth inputRef={nameInputRef} label="Name" />
+            <TextField sx={{ marginTop: '10px' }} fullWidth inputRef={nameInputRef} label="Name" autoFocus />
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setShowPrompt(false)}>Cancel</Button>

--- a/packages/powersync-sdk-web/package.json
+++ b/packages/powersync-sdk-web/package.json
@@ -41,7 +41,7 @@
     "@journeyapps/wa-sqlite": "~0.1.0"
   },
   "dependencies": {
-    "@journeyapps/powersync-sdk-common": "1.0.0",
+    "@journeyapps/powersync-sdk-common": "0.0.0-dev-20240115090623",
     "async-mutex": "^0.4.0",
     "comlink": "^4.4.1",
     "js-logger": "^1.6.1",

--- a/packages/powersync-sdk-web/package.json
+++ b/packages/powersync-sdk-web/package.json
@@ -41,7 +41,7 @@
     "@journeyapps/wa-sqlite": "~0.1.0"
   },
   "dependencies": {
-    "@journeyapps/powersync-sdk-common": "0.0.0-dev-20240115090623",
+    "@journeyapps/powersync-sdk-common": "1.0.1",
     "async-mutex": "^0.4.0",
     "comlink": "^4.4.1",
     "js-logger": "^1.6.1",

--- a/packages/powersync-sdk-web/src/db/adapters/AbstractWebPowerSyncDatabaseOpenFactory.ts
+++ b/packages/powersync-sdk-web/src/db/adapters/AbstractWebPowerSyncDatabaseOpenFactory.ts
@@ -65,6 +65,7 @@ export abstract class AbstractWebPowerSyncDatabaseOpenFactory extends AbstractPo
     }
 
     return {
+      ...this.options,
       database: isServerSide ? new SSRDBAdapter() : this.openDB(),
       schema: this.schema,
       flags: resolvedFlags

--- a/packages/powersync-sdk-web/src/worker/db/open-db.ts
+++ b/packages/powersync-sdk-web/src/worker/db/open-db.ts
@@ -24,6 +24,8 @@ export type WASQLiteExecuteMethod = (sql: string, params?: any[]) => Promise<WAS
 export type OnTableChangeCallback = (opType: number, tableName: string, rowId: number) => void;
 export type OpenDB = (dbFileName: string) => DBWorkerInterface;
 
+const listeners = new Map<string, OnTableChangeCallback>();
+
 export async function _openDB(dbFileName: string): Promise<DBWorkerInterface> {
   const { default: moduleFactory } = await import('@journeyapps/wa-sqlite/dist/wa-sqlite-async.mjs');
   const module = await moduleFactory();
@@ -34,7 +36,6 @@ export async function _openDB(dbFileName: string): Promise<DBWorkerInterface> {
   sqlite3.vfs_register(vfs, true);
 
   const db = await sqlite3.open_v2(dbFileName);
-  const listeners = new Map<string, OnTableChangeCallback>();
 
   sqlite3.register_table_onchange_hook(db, (opType: number, tableName: string, rowId: number) => {
     Array.from(listeners.values()).forEach((l) => l(opType, tableName, rowId));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8
       '@journeyapps/powersync-react':
-        specifier: 0.0.0-dev-20240115090623
-        version: 0.0.0-dev-20240115090623(react@18.0.0)
+        specifier: 1.0.1
+        version: 1.0.1(react@18.0.0)
       '@journeyapps/powersync-sdk-web':
         specifier: workspace:*
         version: link:../../packages/powersync-sdk-web
@@ -138,8 +138,8 @@ importers:
   packages/powersync-sdk-web:
     dependencies:
       '@journeyapps/powersync-sdk-common':
-        specifier: 0.0.0-dev-20240115090623
-        version: 0.0.0-dev-20240115090623
+        specifier: 1.0.1
+        version: 1.0.1
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -1948,17 +1948,17 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@journeyapps/powersync-react@0.0.0-dev-20240115090623(react@18.0.0):
-    resolution: {integrity: sha512-P6QA+zVQny1vqwCkZ+uD+mL4B/wxDSrIIqyHG1iVamduSGw0btj9uRdlpKhMkB+AV9TnQNiiGUbH95blrHaVGg==}
+  /@journeyapps/powersync-react@1.0.1(react@18.0.0):
+    resolution: {integrity: sha512-0DCF4C2OijDnxT03dEsrnP2Qhn4k/XwOzdQeLJR7aPS6vr3TTbn//TFSPO8caJmWfZnh3a65uSVlXOvodfpfXQ==}
     peerDependencies:
       react: '*'
     dependencies:
-      '@journeyapps/powersync-sdk-common': 0.0.0-dev-20240115090623
+      '@journeyapps/powersync-sdk-common': 1.0.1
       react: 18.0.0
     dev: false
 
-  /@journeyapps/powersync-sdk-common@0.0.0-dev-20240115090623:
-    resolution: {integrity: sha512-nQCDVSD+d4aXpUz3X5Ndanues0DtcXpp8JT4u2nwdmARada6MIJNh29nyvvE4IvN84mnM731brohKihZnWMEqg==}
+  /@journeyapps/powersync-sdk-common@1.0.1:
+    resolution: {integrity: sha512-MTAAHyL3jbvknXBuroDheoNDvyntH1Wt/HPLopnaFupg13eJRx/1vvAPd5KRmMwpPpGL+j7P5zMJ+YgvRYIXzw==}
     dependencies:
       async-mutex: 0.4.0
       can-ndjson-stream: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8
       '@journeyapps/powersync-react':
-        specifier: 1.0.0
-        version: 1.0.0(react@18.0.0)
+        specifier: 0.0.0-dev-20240115090623
+        version: 0.0.0-dev-20240115090623(react@18.0.0)
       '@journeyapps/powersync-sdk-web':
         specifier: workspace:*
         version: link:../../packages/powersync-sdk-web
@@ -138,8 +138,8 @@ importers:
   packages/powersync-sdk-web:
     dependencies:
       '@journeyapps/powersync-sdk-common':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 0.0.0-dev-20240115090623
+        version: 0.0.0-dev-20240115090623
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -1948,17 +1948,17 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@journeyapps/powersync-react@1.0.0(react@18.0.0):
-    resolution: {integrity: sha512-WMSIScA4cZbBBFAD9p/v6vn/0ixv0tLaVMcx84pIkUSy9FNn8gI0G9ciwUIcyGSNI1sMnCjyH76NwXo48WtY5w==}
+  /@journeyapps/powersync-react@0.0.0-dev-20240115090623(react@18.0.0):
+    resolution: {integrity: sha512-P6QA+zVQny1vqwCkZ+uD+mL4B/wxDSrIIqyHG1iVamduSGw0btj9uRdlpKhMkB+AV9TnQNiiGUbH95blrHaVGg==}
     peerDependencies:
       react: '*'
     dependencies:
-      '@journeyapps/powersync-sdk-common': 1.0.0
+      '@journeyapps/powersync-sdk-common': 0.0.0-dev-20240115090623
       react: 18.0.0
     dev: false
 
-  /@journeyapps/powersync-sdk-common@1.0.0:
-    resolution: {integrity: sha512-mVyIsWiSQPMvAcQ715x+qomYp9C2LZKi/k+w7ZMpWN3KrwIPNWskF6DYHGOwnl9J0uaDC74T9yrwmVganEa3JQ==}
+  /@journeyapps/powersync-sdk-common@0.0.0-dev-20240115090623:
+    resolution: {integrity: sha512-nQCDVSD+d4aXpUz3X5Ndanues0DtcXpp8JT4u2nwdmARada6MIJNh29nyvvE4IvN84mnM731brohKihZnWMEqg==}
     dependencies:
       async-mutex: 0.4.0
       can-ndjson-stream: 1.0.2


### PR DESCRIPTION
This updates the common SDK to v1.0.1. Including changes from https://github.com/powersync-ja/powersync-react-native-sdk/pull/41.

This PR also fixes a bug where opening multiple wa-sqlite instances would clear active DB table watch listeners. 