### PR TITLE
[Fix] Watched Queries Race Condition

### DIFF
--- a/.changeset/eleven-moons-sit.md
+++ b/.changeset/eleven-moons-sit.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Fixed watched queries not updating due to race condition when opening multiple WA-SQLite connections due to initiating multiple PowerSync instances simultaneously.

--- a/packages/powersync-sdk-web/src/worker/db/SharedWASQLiteDB.worker.ts
+++ b/packages/powersync-sdk-web/src/worker/db/SharedWASQLiteDB.worker.ts
@@ -6,24 +6,30 @@ import { DBWorkerInterface, _openDB } from './open-db';
 
 const _self: SharedWorkerGlobalScope = self as any;
 
-const DBMap = new Map<string, DBWorkerInterface>();
+const DBMap = new Map<string, Promise<DBWorkerInterface>>();
 
 const openDB = async (dbFileName: string): Promise<DBWorkerInterface> => {
   if (!DBMap.has(dbFileName)) {
-    DBMap.set(dbFileName, await _openDB(dbFileName));
+    const openPromise = _openDB(dbFileName);
+    DBMap.set(dbFileName, openPromise);
+    openPromise.catch((error) => {
+      // Allow for retries if an error ocurred
+      console.error(error);
+      DBMap.delete(dbFileName);
+    });
   }
-  return Comlink.proxy(DBMap.get(dbFileName)!);
+  return Comlink.proxy(await DBMap.get(dbFileName)!);
 };
 
 _self.onconnect = function (event: MessageEvent<string>) {
   const port = event.ports[0];
-
   console.debug('Exposing db on port', port);
   Comlink.expose(openDB, port);
 };
 
 addEventListener('beforeunload', (event) => {
-  Array.from(DBMap.values()).forEach((db) => {
+  Array.from(DBMap.values()).forEach(async (dbPromise) => {
+    const db = await dbPromise;
     db.close?.();
   });
 });

--- a/packages/powersync-sdk-web/src/worker/db/open-db.ts
+++ b/packages/powersync-sdk-web/src/worker/db/open-db.ts
@@ -24,8 +24,6 @@ export type WASQLiteExecuteMethod = (sql: string, params?: any[]) => Promise<WAS
 export type OnTableChangeCallback = (opType: number, tableName: string, rowId: number) => void;
 export type OpenDB = (dbFileName: string) => DBWorkerInterface;
 
-const listeners = new Map<string, OnTableChangeCallback>();
-
 export async function _openDB(dbFileName: string): Promise<DBWorkerInterface> {
   const { default: moduleFactory } = await import('@journeyapps/wa-sqlite/dist/wa-sqlite-async.mjs');
   const module = await moduleFactory();
@@ -36,6 +34,11 @@ export async function _openDB(dbFileName: string): Promise<DBWorkerInterface> {
   sqlite3.vfs_register(vfs, true);
 
   const db = await sqlite3.open_v2(dbFileName);
+
+  /**
+   * Listeners are exclusive to the DB connection.
+   */
+  const listeners = new Map<string, OnTableChangeCallback>();
 
   sqlite3.register_table_onchange_hook(db, (opType: number, tableName: string, rowId: number) => {
     Array.from(listeners.values()).forEach((l) => l(opType, tableName, rowId));


### PR DESCRIPTION
This PR fixes a race condition which is possible when initialising multiple PowerSync instances simultaneously. 

For example: Initialising PowerSync in a `React.useState` method will initialize two clients if React strict mode is enabled. 

If the web environment is in a fresh state, having no previous DB initialized, the DB opening will take a few seconds. This will create multiple DB connections instead of the shared worker using a single cached connection. Table change updates are triggered per connection and will thus fail if an update is executed on a different connection.  

This PR caches the promise of initialising the DB connection instead of the resolved connection. This should ensure that multiple open requests will still use the same DB connection. 

This PR also reverts the listener change from https://github.com/powersync-ja/powersync-web-sdk/pull/21 as this race condition was the root cause of the issue. 